### PR TITLE
Convert rU to r

### DIFF
--- a/teloclip/__init__.py
+++ b/teloclip/__init__.py
@@ -244,7 +244,7 @@ def read_fai(fai):
     # Init empty dict
     ContigDict = dict()
     # Read fai_file to dict
-    with open(path, "rU") as f:
+    with open(path, "r") as f:
         for line in f.readlines():
             li = line.strip().split()
             ContigDict[li[0]]=int(li[1])

--- a/teloclip/run_extract.py
+++ b/teloclip/run_extract.py
@@ -21,7 +21,7 @@ if not sys.version_info[0] > 2:
 def mainArgs():
     parser = argparse.ArgumentParser(description='Extract overhanging reads for each end of each reference contig. Write to fasta.',prog='teloclip-extract')
     # Input options
-    parser.add_argument('samfile', nargs='?', type=argparse.FileType('rU'), default=sys.stdin)
+    parser.add_argument('samfile', nargs='?', type=argparse.FileType('r'), default=sys.stdin)
     parser.add_argument('--refIdx',type=str,required=True,help='Path to fai index for reference fasta. Index fasta using `samtools faidx FASTA`')
     #parser.add_argument('--refSeq',type=str,required=True,help='Path to reference fasta.')
     # Output options

--- a/teloclip/run_self.py
+++ b/teloclip/run_self.py
@@ -10,7 +10,8 @@ import sys
 def mainArgs():
     parser = argparse.ArgumentParser(description='Filter SAM file for clipped alignments containing unassembled telomeric repeats.',prog='teloclip')
     # Input options
-    parser.add_argument('samfile', nargs='?', type=argparse.FileType('rU'), default=sys.stdin)
+    parser.add_argument('samfile', nargs='?', type=argparse.FileType('r
+    '), default=sys.stdin)
     parser.add_argument('--refIdx',type=str,required=True,help='Path to fai index for reference fasta. Index fasta using `samtools faidx FASTA`')
     parser.add_argument('--minClip',type=int,default=1,help='Require clip to extend past ref contig end by at least N bases.')
     parser.add_argument('--maxBreak',type=int,default=50,help='Tolerate max N unaligned bases at contig ends.')


### PR DESCRIPTION
rU is depreciated in Python 3.11, replace with "r"