### PR TITLE
tidy_reports

### DIFF
--- a/.github/workflows/cff-validator.yml
+++ b/.github/workflows/cff-validator.yml
@@ -12,6 +12,6 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Validate CITATION.cff
         uses: dieghernan/cff-validator@v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "autoDocstring.docstringFormat": "numpy",
   "python.testing.pytestArgs": ["tests"],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": true,
+  "python.analysis.typeCheckingMode": "standard"
 }

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ teloclip extend overhangs.sorted.bam ref.fa \
 
 After manually extending contigs the revised assembly should be re-polished using available long and short read data to correct indels present in the raw long-reads.
 
-The final telomere-extended assembly should be re-polished using available long and short read data to correct indels (i.e. with `Medaka` and `Pypolca`) in the raw long-read extensions.
+The final telomere-extended assembly should be re-polished using available long and short read data to correct indels (i.e. with `NextPolish2` and `Pypolca`) in the raw long-read extensions.
 
 ### Optional Quality Control
 
@@ -474,7 +474,7 @@ Submit feedback to the [Issue Tracker](https://github.com/Adamtaranto/teloclip/i
 
 ## License
 
-Software provided under MIT license.
+Software provided under GPL-3 license.
 
 ## Star History
 

--- a/src/teloclip/commands/extend.py
+++ b/src/teloclip/commands/extend.py
@@ -258,15 +258,12 @@ def generate_extension_report(
 
     # Per-contig summary
     report_lines.append('## Per-Contig Overhang Summary')
-    report_lines.append(
-        'Contig\tLength\tLeft_Count\tRight_Count\tLeft_Total\tRight_Total'
-    )
+    report_lines.append('Contig\tLength\tLeft_Count\tRight_Count')
 
     for contig_name, contig_stats in stats_dict.items():
         report_lines.append(
             f'{contig_name}\t{contig_stats.contig_length}\t'
-            f'{contig_stats.left_count}\t{contig_stats.right_count}\t'
-            f'{contig_stats.left_total_length}\t{contig_stats.right_total_length}'
+            f'{contig_stats.left_count}\t{contig_stats.right_count}'
         )
 
     return '\n'.join(report_lines)


### PR DESCRIPTION
Misc fixes for unclear logging and reports.

Minor UX updates after case testing.

- [ ] Validate and tune automated contig exclusion.
- [ ] Improve extension summary reports.
- [ ] Log per contig total left/right overhang counts.
- [ ] Log histogram for per contig end overhang count in filter and extend.
- [ ] Add html report option for extend module
- [ ] Clarify exclusion stats in filter module
- [ ] Possible OBO error in clip threshold calculation
- [ ] Verify that exclusion contigs actually exist in ref asm index.
- [ ] Option to set logfile name
- [ ] Option to log all overhang reads with: contig end, clip offset from end of contig, len clip, and len overhang. 
- [ ] When excluding contigs from extension, they end up being written to the end of the output fasta. Fix so that output contigs maintain input order. [should we bother? Could just sort with seqtk afterwards.]