### PR TITLE
Add pydocstyle linting to ruff configuration in pyproject.toml

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,7 +51,7 @@ To set up your development environment:
 1. Clone your fork of the repository
 
 ```bash
-git clone https://github.com/adamtaranto/teloclip.git
+git clone https://github.com/{your_user_name}/teloclip.git
 cd teloclip
 ```
 
@@ -65,7 +65,7 @@ conda activate teloclip
 3. Install development dependencies
 
 ```bash
-pip install -e ".[dev]"
+pip install -e ".[dev,docs,test]"
 ```
 
 4. Enable git pre-commit checks

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,12 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 # Set update schedule for GitHub Actions and other dependencies
 version: 2
 updates:
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     # Check for workflow files in the .github/workflows directory
-    directory: "/" 
+    directory: "/"
     schedule:
       interval: "monthly" # Check for updates every month

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       # Checkout the latest commit associated with the PR
       - uses: actions/checkout@v7
@@ -49,7 +49,7 @@ jobs:
       # Only upload coverage for the latest Python version
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Adamtaranto/teloclip

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,14 +13,15 @@ jobs:
         with:
           ref: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: astral-sh/ruff-action@v3
-        with:
-          src: "./src/teloclip ./tests"
-          args: "format"
+      # Run check --fix before format so that any fixes it applies get formatted.
       - uses: astral-sh/ruff-action@v3
         with:
           src: "./src/teloclip ./tests"
           args: "check --fix"
+      - uses: astral-sh/ruff-action@v3
+        with:
+          src: "./src/teloclip ./tests"
+          args: "format"
       - uses: isort/isort-action@v1
         with:
           configuration: "--settings-path=./pyproject.toml"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
-# Package notes
+# Sandpit
 .ideas/
+.plans/
+experiments/
+
+# Agent configs
+.claude/
+.claudeignore
+.env
+.mcp.json
 
 # Mac stuff
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,30 +15,29 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: end-of-file-fixer
-      - id: end-of-file-fixer
       - id: name-tests-test
         args: [--pytest-test-first]
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
       - id: ruff-format
   - repo: https://github.com/numpy/numpydoc
-    rev: v1.9.0
+    rev: v1.11.0rc0
     hooks:
       - id: numpydoc-validation
         exclude: (tests/|docs/).*
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.8
+    rev: v1.7.12
     hooks:
       - id: actionlint
   - repo: https://github.com/google/yamlfmt
-    rev: v0.20.0
+    rev: v0.21.0
     hooks:
       - id: yamlfmt
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
+#  - repo: https://github.com/pre-commit/mirrors-prettier
+#    rev: v4.0.0-alpha.8
+#    hooks:
+#      - id: prettier

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,18 +1,23 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
 cff-version: 1.2.0
+title: teloclip
 message: "If you use this software, please cite it as below."
-title: "teloclip"
-version: 0.3.4
-date-released: 2025-11-07
+type: software
 authors:
   - family-names: Taranto
     given-names: Adam
-    orcid: https://orcid.org/0000-0003-4759-3475
-    affiliation: "The University of Melbourne"
+    orcid: "https://orcid.org/0000-0003-4759-3475"
+    affiliation: The University of Melbourne
 repository-code: "https://github.com/Adamtaranto/teloclip"
-license: GPL-3.0-or-later
 abstract: >-
-  A tool for the recovery of unassembled telomeres from raw long-reads using soft-clipped read alignments.
+  A tool for the recovery of unassembled telomeres from raw
+  long-reads using soft-clipped read alignments.
 keywords:
   - genomics
   - telomeres
   - bioinformatics
+license: GPL-3.0-or-later
+version: 0.3.4
+date-released: "2025-11-07"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![PyPI version](https://badge.fury.io/py/teloclip.svg)](https://badge.fury.io/py/teloclip)
 [![codecov](https://codecov.io/gh/adamtaranto/teloclip/graph/badge.svg?token=NBS8YPLZDT)](https://codecov.io/gh/adamtaranto/teloclip)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/teloclip/README.html)

--- a/README.md
+++ b/README.md
@@ -478,5 +478,10 @@ Software provided under GPL-3 license.
 
 ## Star History
 
-[![Star History
-Chart](https://api.star-history.com/svg?repos=adamtaranto/teloclip&type=Date)](https://star-history.com/#adamtaranto/teloclip&Date)
+<a href="https://www.star-history.com/?repos=Adamtaranto%2Fteloclip&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Adamtaranto/teloclip&type=date&theme=dark&legend=top-left&sealed_token=jCjxdn3HLLirH-ScvCrYTN-0ifrY4W7QfxFw9K0PsgyDTl_ibIlzfv5kFzeGd_7mzLL14Ftmm6SeBzyKBXHzdMOsjkyJERa1irqLV-QpsqZ6FlcKyytaZOLLbM72VECXt78_7k4-SXz6eh3F-nRAyMZMP6mBOXZJ4TyRHAAae4-w4s8SZ1Bx_F7-kgN2" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Adamtaranto/teloclip&type=date&legend=top-left&sealed_token=jCjxdn3HLLirH-ScvCrYTN-0ifrY4W7QfxFw9K0PsgyDTl_ibIlzfv5kFzeGd_7mzLL14Ftmm6SeBzyKBXHzdMOsjkyJERa1irqLV-QpsqZ6FlcKyytaZOLLbM72VECXt78_7k4-SXz6eh3F-nRAyMZMP6mBOXZJ4TyRHAAae4-w4s8SZ1Bx_F7-kgN2" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Adamtaranto/teloclip&type=date&legend=top-left&sealed_token=jCjxdn3HLLirH-ScvCrYTN-0ifrY4W7QfxFw9K0PsgyDTl_ibIlzfv5kFzeGd_7mzLL14Ftmm6SeBzyKBXHzdMOsjkyJERa1irqLV-QpsqZ6FlcKyytaZOLLbM72VECXt78_7k4-SXz6eh3F-nRAyMZMP6mBOXZJ4TyRHAAae4-w4s8SZ1Bx_F7-kgN2" />
+ </picture>
+</a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![PyPI version](https://badge.fury.io/py/teloclip.svg)](https://badge.fury.io/py/teloclip)
 [![codecov](https://codecov.io/gh/adamtaranto/teloclip/graph/badge.svg?token=NBS8YPLZDT)](https://codecov.io/gh/adamtaranto/teloclip)
-[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/teloclip/README.html)
+[![BioConda Install](https://img.shields.io/conda/dn/bioconda/teloclip.svg?style=flag&label=BioConda%20install)](https://anaconda.org/bioconda/teloclip)
 [![Downloads](https://pepy.tech/badge/teloclip)](https://pepy.tech/project/teloclip)
 [![Docker Image](https://img.shields.io/docker/v/adamtaranto/teloclip?label=docker&color=blue)](https://hub.docker.com/r/adamtaranto/teloclip)
 [![Docker Pulls](https://img.shields.io/docker/pulls/adamtaranto/teloclip)](https://hub.docker.com/r/adamtaranto/teloclip)
@@ -90,15 +90,7 @@ This is the best way to ensure you have the latest development version.
 pip install git+https://github.com/Adamtaranto/teloclip.git
 ```
 
-4. Clone from this repository and install as a local Python package.
-
-Do this if you want to edit the code.
-
-```bash
-git clone https://github.com/Adamtaranto/teloclip.git && cd teloclip && pip install -e '.[dev]'
-```
-
-5. Use Docker for reproducible containerized environments.
+4. Use Docker for reproducible containerized environments.
 
 Ideal for pipelines and reproducible workflows. No local Python installation required.
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,14 +8,8 @@ dependencies:
   - pip
   - pyfaidx
   - pysam
-  - python >=3.12
+  - python 3.14
   - samtools
-  - pip:
-      - click
-      - hatch
-      - isort
-      - numpydoc-validation
-      - pre-commit
-      - pytest
-      - pytest-cov
-      - ruff
+#  - pip:
+#      - isort
+#      - ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ select = [
     "W", # pycodestyle warning rules
     "B", # flake8-bugbear rules
     "I", # isort rules
+    "D", # pydocstyle rules
 ]
 ignore = [
     "C901", # max-complexity-10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,14 @@ teloclip = "teloclip.cli:main"
 [tool.hatch.build]
 source = "src"
 
-exclude = ["environment.yml", ".github", ".vscode"]
+exclude = [
+    "environment.yml",
+    ".github",
+    ".vscode",
+    "tests",
+    "scripts",
+    "examples",
+]
 
 [tool.hatch.version]
 source = "vcs"
@@ -80,9 +87,12 @@ select = [
 ignore = [
     "C901", # max-complexity-10
     "E501", # line-too-long
-    "I001", # isort-imports
+    #"I001", # isort-imports
     "B905", # `zip()` without an explicit `strict=` parameter
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.ruff.format]
 indent-style = "space"
@@ -113,3 +123,14 @@ override_SS05 = [ # allow docstrings to start with these words
     '^Assess ',
     '^Access ',
 ]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+
+[tool.pydocstyle]
+convention = "numpy"
+# Ignore files in directories named "tests"
+match-dir = "((?!tests).)*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,17 @@ dev = [
     "ruff",
 ]
 
-test = [
-        "pytest-cov",
-        "pytest",
-        ]
+docs = [
+    "zensical>=0.0.51",
+    "mkdocstrings-python",
+    "mkdocstrings",
+    "notebook",
+    "nbconvert",
+    "pymdown-extensions>=10.21.2,<11",
+    "seaborn",
+]
+
+test = ["pytest", "pytest-codspeed", "pytest-cov"]
 
 [project.urls]
 documentation = "https://github.com/adamtaranto/teloclip"
@@ -97,6 +104,13 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+# Mirror [tool.isort] below. Ruff does not read [tool.isort], so without this
+# the ruff "I" rules and the isort CI step disagree on import order.
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = ["teloclip"]
+known-third-party = ["biopython", "click", "pyfaidx", "pysam", "rich"]
 
 [tool.ruff.format]
 indent-style = "space"

--- a/src/teloclip/__init__.py
+++ b/src/teloclip/__init__.py
@@ -1,3 +1,1 @@
-"""
-Teloclip is a tool for the recovery of unassembled telomeres from soft-clipped read alignments.
-"""
+"""Teloclip is a tool for the recovery of unassembled telomeres from soft-clipped read alignments."""

--- a/src/teloclip/analysis.py
+++ b/src/teloclip/analysis.py
@@ -5,9 +5,9 @@ This module provides functionality to analyze soft-clipped alignments and collec
 statistics about overhanging sequences that can be used to extend draft contigs.
 """
 
-from dataclasses import dataclass, field
 import logging
 import statistics
+from dataclasses import dataclass, field
 from typing import Dict, Iterator, List, Optional, Tuple
 
 from .samops import checkClips, splitCIGAR

--- a/src/teloclip/analysis.py
+++ b/src/teloclip/analysis.py
@@ -5,9 +5,9 @@ This module provides functionality to analyze soft-clipped alignments and collec
 statistics about overhanging sequences that can be used to extend draft contigs.
 """
 
+from dataclasses import dataclass, field
 import logging
 import statistics
-from dataclasses import dataclass, field
 from typing import Dict, Iterator, List, Optional, Tuple
 
 from .samops import checkClips, splitCIGAR

--- a/src/teloclip/cli.py
+++ b/src/teloclip/cli.py
@@ -1,6 +1,4 @@
-"""
-Main CLI entry point for teloclip with sub-commands.
-"""
+"""Main CLI entry point for teloclip with sub-commands."""
 
 import click
 
@@ -15,7 +13,7 @@ from teloclip._version import __version__
 @click.pass_context
 def main(ctx):
     """
-    A tool for the recovery of unassembled telomeres from soft-clipped read alignments.
+    Teloclip is a tool for the recovery of unassembled telomeres from soft-clipped read alignments.
 
     Use sub-commands to filter alignments, extract reads, or extend contigs.
 

--- a/src/teloclip/commands/__init__.py
+++ b/src/teloclip/commands/__init__.py
@@ -1,3 +1,1 @@
-"""
-Commands package for teloclip CLI.
-"""
+"""Commands package for teloclip CLI."""

--- a/src/teloclip/commands/extend.py
+++ b/src/teloclip/commands/extend.py
@@ -9,9 +9,9 @@ to avoid loading entire genomes into memory.
 """
 
 import logging
-from pathlib import Path
 import re
 import sys
+from pathlib import Path
 from typing import Dict, List
 
 import click
@@ -561,7 +561,6 @@ def get_motif_regex(motif_str: str, fuzzy: bool = False) -> Dict[str, re.Pattern
     Dict[str, re.Pattern]
         Dictionary mapping motif sequences to compiled regex patterns.
     """
-
     # Initialize motif patterns dictionary
     motif_patterns = {}
     # Parse comma-delimited motifs

--- a/src/teloclip/commands/extend.py
+++ b/src/teloclip/commands/extend.py
@@ -9,10 +9,10 @@ to avoid loading entire genomes into memory.
 """
 
 import logging
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
 import click
 import pyfaidx
@@ -20,6 +20,7 @@ import pysam
 
 from ..analysis import ContigStats, calculate_overhang_statistics
 from ..motifs import make_fuzzy_motif_regex, make_motif_regex
+from ..reporting import fmt_delta, fmt_float, fmt_int, kv_table, md_table
 from ..seqops import read_fai, revComp
 from ..streaming_analysis import (
     process_single_contig_extension,
@@ -66,6 +67,92 @@ def validate_output_directories(output_fasta: Path, stats_report: Path) -> None:
                     ) from e
 
 
+def _extension_lengths(ext_info: Dict) -> Tuple[int, int]:
+    """
+    Extract the left and right extension lengths from an extension record.
+
+    Parameters
+    ----------
+    ext_info : Dict
+        Extension info dictionary as stored in ``extensions_applied``.
+
+    Returns
+    -------
+    Tuple[int, int]
+        Bases added at the left end and at the right end.
+    """
+    left = (
+        ext_info.get('left_overhang_length', 0)
+        if ext_info.get('has_left_extension', False)
+        else 0
+    )
+    right = (
+        ext_info.get('right_overhang_length', 0)
+        if ext_info.get('has_right_extension', False)
+        else 0
+    )
+    return left, right
+
+
+def _motif_gain_rows(
+    extensions_applied: Dict[str, dict],
+    terminal_motif_counts: Dict[str, Dict[str, Dict[str, int]]],
+    post_motif_counts: Dict[str, Dict[str, Dict[str, int]]],
+    screen_terminal_bases: int,
+) -> Tuple[List[List[str]], int]:
+    """
+    Build the per-end motif analysis table rows.
+
+    Parameters
+    ----------
+    extensions_applied : Dict[str, dict]
+        Extension records keyed by contig name.
+    terminal_motif_counts : Dict[str, Dict[str, Dict[str, int]]]
+        Pre-extension motif counts, ``contig -> end -> motif -> count``, counted
+        over the ``--screen-terminal-bases`` window.
+    post_motif_counts : Dict[str, Dict[str, Dict[str, int]]]
+        Post-extension motif counts over the same window plus the length of the
+        extension at that end.
+    screen_terminal_bases : int
+        Size of the pre-extension screening window, in bases.
+
+    Returns
+    -------
+    Tuple[List[List[str]], int]
+        Table rows and the total motif gain summed across all contig ends.
+    """
+    rows: List[List[str]] = []
+    total_gain = 0
+
+    for contig_name in sorted(post_motif_counts):
+        end_counts = post_motif_counts[contig_name]
+        pre_counts = terminal_motif_counts.get(contig_name, {})
+        left_added, right_added = _extension_lengths(
+            extensions_applied.get(contig_name, {})
+        )
+
+        for end, added in (('left', left_added), ('right', right_added)):
+            window = screen_terminal_bases + added
+            for motif_name in sorted(end_counts.get(end, {})):
+                post = end_counts[end][motif_name]
+                pre = pre_counts.get(end, {}).get(motif_name, 0)
+                gain = post - pre
+                total_gain += gain
+                rows.append(
+                    [
+                        contig_name,
+                        end,
+                        motif_name,
+                        fmt_int(window),
+                        fmt_int(pre),
+                        fmt_int(post),
+                        fmt_delta(gain),
+                    ]
+                )
+
+    return rows, total_gain
+
+
 def generate_extension_report(
     stats_dict: Dict[str, ContigStats],
     extensions_applied: Dict[str, dict],
@@ -73,200 +160,338 @@ def generate_extension_report(
     overall_stats: Dict[str, Dict[str, float]],
     excluded_contigs: List[str],
     warnings: List[str],
-    motif_stats: Dict[str, Dict[str, int]] = None,
-    terminal_motif_counts: Dict[str, Dict[str, Dict[str, int]]] = None,
+    motif_stats: Optional[Dict[str, Dict[str, int]]] = None,
+    terminal_motif_counts: Optional[Dict[str, Dict[str, Dict[str, int]]]] = None,
     dry_run: bool = False,
+    post_motif_counts: Optional[Dict[str, Dict[str, Dict[str, int]]]] = None,
+    screen_terminal_bases: int = 0,
+    total_contigs: Optional[int] = None,
 ) -> str:
     """
-    Generate a comprehensive statistics report for contig extension analysis.
+    Generate a Markdown statistics report for a contig extension run.
+
+    The report opens with an at-a-glance summary and then presents per-contig
+    detail as GitHub-flavoured Markdown tables, which also read as aligned
+    plain text in a terminal.
 
     Parameters
     ----------
     stats_dict : Dict[str, ContigStats]
-        Dictionary mapping contig names to their statistics.
+        Overhang statistics for every contig with overhang support.
     extensions_applied : Dict[str, dict]
-        Dictionary of extensions that were applied to contigs.
+        Extension records keyed by contig name.
     outliers : Dict[str, List[str]]
-        Dictionary of outlier contigs by category.
+        Outlier contig names under the keys ``left_outliers`` and
+        ``right_outliers``.
     overall_stats : Dict[str, Dict[str, float]]
-        Overall statistics across all contigs.
+        Aggregate overhang statistics keyed by ``left``, ``right`` and
+        ``combined``.
     excluded_contigs : List[str]
-        List of contig names that were excluded from analysis.
+        Contigs excluded from extension by the user.
     warnings : List[str]
-        List of warning messages generated during analysis.
-    motif_stats : Dict[str, Dict[str, int]], optional
-        Statistics about motif occurrences. Default is None.
-    terminal_motif_counts : Dict[str, Dict[str, Dict[str, int]]], optional
-        Pre-extension terminal motif counts. Default is None.
+        Warning messages accumulated during the run.
+    motif_stats : Optional[Dict[str, Dict[str, int]]], optional
+        Whole-sequence motif counts per extended contig.
+    terminal_motif_counts : Optional[Dict[str, Dict[str, Dict[str, int]]]], optional
+        Pre-extension motif counts per contig end.
     dry_run : bool, optional
-        Whether this is a dry run (no actual extensions applied). Default is False.
+        Whether extensions were simulated rather than applied (default: False).
+    post_motif_counts : Optional[Dict[str, Dict[str, Dict[str, int]]]], optional
+        Post-extension motif counts per contig end, counted over the screening
+        window plus the extension length at that end.
+    screen_terminal_bases : int, optional
+        Size of the terminal screening window in bases (default: 0).
+    total_contigs : Optional[int], optional
+        Number of contigs in the input assembly. Falls back to the number of
+        contigs with overhang support when not supplied.
 
     Returns
     -------
     str
-        Formatted statistics report as a multi-line string.
+        The rendered Markdown report.
     """
-    report_lines = []
+    motif_stats = motif_stats or {}
+    terminal_motif_counts = terminal_motif_counts or {}
+    post_motif_counts = post_motif_counts or {}
 
+    lines: List[str] = []
+
+    def section(title: str, body: str) -> None:
+        """
+        Append a titled section to the report, skipping empty bodies.
+
+        Parameters
+        ----------
+        title : str
+            Section heading text, without the leading ``##``.
+        body : str
+            Rendered section body.
+
+        Returns
+        -------
+        None
+            The section is appended to the enclosing ``lines`` list.
+        """
+        if not body:
+            return
+        lines.append(f'## {title}')
+        lines.append('')
+        lines.append(body)
+        lines.append('')
+
+    # ------------------------------------------------------------------
+    # Title
+    # ------------------------------------------------------------------
+    title = 'Teloclip Extend Report'
     if dry_run:
-        report_lines.append('# Teloclip Extend Statistics Report (DRY RUN)')
-    else:
-        report_lines.append('# Teloclip Extend Statistics Report')
-    report_lines.append('=' * 50)
-    report_lines.append('')
+        title += ' (dry run)'
+    lines.append(f'# {title}')
+    lines.append('')
 
-    # Overall statistics
-    report_lines.append('## Overall Overhang Statistics')
-    for category, stats in overall_stats.items():
-        report_lines.append(f'\n### {category.title()} Overhangs')
-        for metric, value in stats.items():
-            report_lines.append(f'  {metric}: {value:.2f}')
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    n_contigs = total_contigs if total_contigs is not None else len(stats_dict)
+    ends_extended = 0
+    total_gained = 0
+    total_trimmed = 0
 
-    report_lines.append('')
+    for ext_info in extensions_applied.values():
+        left_added, right_added = _extension_lengths(ext_info)
+        ends_extended += int(left_added > 0) + int(right_added > 0)
+        total_gained += left_added + right_added
+        total_trimmed += ext_info.get('left_trim_length', 0) + ext_info.get(
+            'right_trim_length', 0
+        )
 
+    motif_rows, total_motif_gain = _motif_gain_rows(
+        extensions_applied,
+        terminal_motif_counts,
+        post_motif_counts,
+        screen_terminal_bases,
+    )
+
+    motif_names = sorted(
+        {
+            motif
+            for counts in post_motif_counts.values()
+            for end in counts.values()
+            for motif in end
+        }
+    )
+
+    summary_pairs = [
+        ('Mode', 'dry run (no sequences written)' if dry_run else 'extension applied'),
+        ('Contigs in assembly', fmt_int(n_contigs)),
+        ('Contigs with overhang support', fmt_int(len(stats_dict))),
+        ('Contigs extended', fmt_int(len(extensions_applied))),
+        (
+            'Contig ends extended',
+            f'{fmt_int(ends_extended)} of {fmt_int(n_contigs * 2)}',
+        ),
+        ('Total bases added', fmt_int(total_gained)),
+        ('Total bases trimmed back', fmt_int(total_trimmed)),
+    ]
+    if motif_names:
+        summary_pairs.append(('Motifs counted', ', '.join(motif_names)))
+        summary_pairs.append(('Total motif gain', fmt_delta(total_motif_gain)))
+    if screen_terminal_bases > 0:
+        summary_pairs.append(
+            ('Terminal screening window', f'{fmt_int(screen_terminal_bases)} bp')
+        )
+    summary_pairs.append(('Contigs excluded', fmt_int(len(excluded_contigs))))
+    summary_pairs.append(('Warnings', fmt_int(len(warnings))))
+
+    section('Summary', kv_table(summary_pairs))
+
+    # ------------------------------------------------------------------
     # Extensions applied
-    if dry_run:
-        report_lines.append('## Extensions That Would Be Applied')
-        report_lines.append(
-            f'Total contigs that would be extended: {len(extensions_applied)}'
+    # ------------------------------------------------------------------
+    ext_rows: List[List[str]] = []
+    for contig_name in sorted(extensions_applied):
+        ext_info = extensions_applied[contig_name]
+        left_added, right_added = _extension_lengths(ext_info)
+        ext_rows.append(
+            [
+                contig_name,
+                fmt_int(ext_info.get('original_length', 0)),
+                fmt_int(ext_info.get('final_length', 0)),
+                fmt_delta(left_added),
+                fmt_delta(right_added),
+                fmt_delta(left_added + right_added),
+                ext_info.get('left_read_name', '-') if left_added else '-',
+                ext_info.get('right_read_name', '-') if right_added else '-',
+                fmt_int(ext_info.get('left_trim_length', 0)),
+                fmt_int(ext_info.get('right_trim_length', 0)),
+            ]
         )
-    else:
-        report_lines.append('## Extensions Applied')
-        report_lines.append(f'Total contigs extended: {len(extensions_applied)}')
-    report_lines.append('')
 
-    for contig_name, ext_info in extensions_applied.items():
-        report_lines.append(f'### {contig_name}')
-        report_lines.append(f'  Original length: {ext_info["original_length"]:,}')
-        report_lines.append(f'  Final length: {ext_info["final_length"]:,}')
+    section(
+        'Extensions That Would Be Applied' if dry_run else 'Extensions Applied',
+        md_table(
+            [
+                'Contig',
+                'Original bp',
+                'Final bp',
+                'Left +bp',
+                'Right +bp',
+                'Total +bp',
+                'Left read',
+                'Right read',
+                'Left trim',
+                'Right trim',
+            ],
+            ext_rows,
+            align=['l', 'r', 'r', 'r', 'r', 'r', 'l', 'l', 'r', 'r'],
+        ),
+    )
 
-        # Report left extension if present
-        if ext_info.get('has_left_extension', False):
-            left_length = ext_info.get('left_overhang_length', 0)
-            left_read = ext_info.get('left_read_name', 'unknown')
-            left_trim = ext_info.get('left_trim_length', 0)
-            report_lines.append(
-                f'  Left extension: +{left_length}bp from read {left_read}'
+    # ------------------------------------------------------------------
+    # Motif analysis
+    # ------------------------------------------------------------------
+    if motif_rows:
+        lines.append('## Telomere Motif Analysis')
+        lines.append('')
+        lines.append(
+            f'Counts are per contig end. `Pre` counts the {fmt_int(screen_terminal_bases)} bp '
+            'terminal screening window of the original contig; `Post` counts that same window '
+            'plus the bases added at that end, in the extended contig.'
+        )
+        lines.append('')
+        lines.append(
+            md_table(
+                ['Contig', 'End', 'Motif', 'Window bp', 'Pre', 'Post', 'Gain'],
+                motif_rows,
+                align=['l', 'l', 'l', 'r', 'r', 'r', 'r'],
             )
-            if left_trim > 0:
-                report_lines.append(f'    Left bases trimmed: {left_trim}')
+        )
+        lines.append('')
+        lines.append(f'**Total motif gain: {fmt_delta(total_motif_gain)}**')
+        lines.append('')
 
-        # Report right extension if present
-        if ext_info.get('has_right_extension', False):
-            right_length = ext_info.get('right_overhang_length', 0)
-            right_read = ext_info.get('right_read_name', 'unknown')
-            right_trim = ext_info.get('right_trim_length', 0)
-            report_lines.append(
-                f'  Right extension: +{right_length}bp from read {right_read}'
+    # ------------------------------------------------------------------
+    # Overhang statistics
+    # ------------------------------------------------------------------
+    n_left = sum(cs.left_count for cs in stats_dict.values())
+    n_right = sum(cs.right_count for cs in stats_dict.values())
+    set_counts = {'left': n_left, 'right': n_right, 'combined': n_left + n_right}
+
+    stat_rows: List[List[str]] = []
+    for label in ('left', 'right', 'combined'):
+        stats = overall_stats.get(label)
+        if not stats:
+            continue
+        stat_rows.append(
+            [
+                label.title(),
+                fmt_int(set_counts[label]),
+                fmt_float(stats.get('mean', 0.0)),
+                fmt_float(stats.get('median', 0.0)),
+                fmt_float(stats.get('std_dev', 0.0)),
+                fmt_int(int(stats.get('min', 0))),
+                fmt_int(int(stats.get('max', 0))),
+            ]
+        )
+
+    section(
+        'Overhang Length Statistics',
+        md_table(
+            ['Set', 'N', 'Mean', 'Median', 'SD', 'Min', 'Max'],
+            stat_rows,
+            align=['l', 'r', 'r', 'r', 'r', 'r', 'r'],
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # Per-contig overhang support
+    # ------------------------------------------------------------------
+    support_rows: List[List[str]] = []
+    for contig_name in sorted(stats_dict):
+        contig_stats = stats_dict[contig_name]
+        longest_left = max((oh.length for oh in contig_stats.left_overhangs), default=0)
+        longest_right = max(
+            (oh.length for oh in contig_stats.right_overhangs), default=0
+        )
+        ext_info = extensions_applied.get(contig_name, {})
+        left_added, right_added = _extension_lengths(ext_info)
+        if left_added and right_added:
+            extended = 'both'
+        elif left_added:
+            extended = 'left'
+        elif right_added:
+            extended = 'right'
+        else:
+            extended = 'no'
+        support_rows.append(
+            [
+                contig_name,
+                fmt_int(contig_stats.contig_length),
+                fmt_int(contig_stats.left_count),
+                fmt_int(contig_stats.right_count),
+                fmt_int(longest_left),
+                fmt_int(longest_right),
+                extended,
+            ]
+        )
+
+    if support_rows:
+        lines.append('## Per-Contig Overhang Support')
+        lines.append('')
+        lines.append(
+            'Read counts are clipped reads anchored at that contig end which passed '
+            'filtering. `Longest` is the longest overhang seen at that end, which is the '
+            'sequence used for extension unless it failed a homopolymer or length check.'
+        )
+        lines.append('')
+        lines.append(
+            md_table(
+                [
+                    'Contig',
+                    'Length',
+                    'Left reads',
+                    'Right reads',
+                    'Longest left',
+                    'Longest right',
+                    'Extended',
+                ],
+                support_rows,
+                align=['l', 'r', 'r', 'r', 'r', 'r', 'l'],
             )
-            if right_trim > 0:
-                report_lines.append(f'    Right bases trimmed: {right_trim}')
+        )
+        lines.append('')
 
-        # Fallback for backward compatibility (single extension)
-        if not ext_info.get('has_left_extension', False) and not ext_info.get(
-            'has_right_extension', False
-        ):
-            direction = 'Left' if ext_info.get('is_left', False) else 'Right'
-            report_lines.append(f'  Direction: {direction}')
-            report_lines.append(
-                f'  Extension length: {ext_info.get("overhang_length", 0)}'
-            )
-            report_lines.append(
-                f'  Source read: {ext_info.get("read_name", "unknown")}'
-            )
-            if ext_info.get('trim_length', 0) > 0:
-                report_lines.append(f'  Bases trimmed: {ext_info["trim_length"]}')
+    # ------------------------------------------------------------------
+    # Excluded contigs and outliers
+    # ------------------------------------------------------------------
+    exclusion_rows = [[contig, 'user exclusion list'] for contig in excluded_contigs]
+    for contig in outliers.get('left_outliers', []):
+        exclusion_rows.append([contig, 'left overhang outlier'])
+    for contig in outliers.get('right_outliers', []):
+        exclusion_rows.append([contig, 'right overhang outlier'])
 
-        report_lines.append('')
+    section(
+        'Excluded Contigs',
+        md_table(['Contig', 'Reason'], exclusion_rows, align=['l', 'l']),
+    )
 
-    # Terminal motif screening results
-    if terminal_motif_counts:
-        report_lines.append('## Terminal Region Motif Analysis (Pre-Extension)')
-        report_lines.append('')
-        for contig_name, terminal_counts in terminal_motif_counts.items():
-            left_total = sum(terminal_counts['left'].values())
-            right_total = sum(terminal_counts['right'].values())
-            if left_total > 0 or right_total > 0:
-                report_lines.append(f'### {contig_name}')
-                report_lines.append(f'  Left terminal: {left_total} total motifs')
-                for motif_name, count in terminal_counts['left'].items():
-                    if count > 0:
-                        report_lines.append(f'    {motif_name}: {count}')
-                report_lines.append(f'  Right terminal: {right_total} total motifs')
-                for motif_name, count in terminal_counts['right'].items():
-                    if count > 0:
-                        report_lines.append(f'    {motif_name}: {count}')
-                report_lines.append('')
-
-    # Extension motif analysis results
-    if motif_stats:
-        report_lines.append('## Extension Region Motif Analysis (Post-Extension)')
-        report_lines.append('')
-        for contig_name, motif_counts in motif_stats.items():
-            if any(count > 0 for count in motif_counts.values()):
-                report_lines.append(f'### {contig_name}')
-                for motif_name, count in motif_counts.items():
-                    if count > 0:
-                        report_lines.append(f'  {motif_name}: {count} matches')
-
-                        # Calculate gain if terminal counts available
-                        if (
-                            terminal_motif_counts
-                            and contig_name in terminal_motif_counts
-                        ):
-                            # Determine which terminal was extended
-                            extension_info = extensions_applied.get(contig_name, {})
-                            if extension_info:
-                                is_left = extension_info.get('is_left', False)
-                                terminal_side = 'left' if is_left else 'right'
-                                pre_count = terminal_motif_counts[contig_name][
-                                    terminal_side
-                                ].get(motif_name, 0)
-                                gain = count - pre_count
-                                if gain != 0:
-                                    report_lines.append(
-                                        f'    Gain from extension: {gain:+d}'
-                                    )
-                report_lines.append('')
-
-    # Outliers detected
-    if any(outliers.values()):
-        report_lines.append('## Outlier Contigs Detected')
-        if outliers['left_outliers']:
-            report_lines.append(
-                f'Left outliers: {", ".join(outliers["left_outliers"])}'
-            )
-        if outliers['right_outliers']:
-            report_lines.append(
-                f'Right outliers: {", ".join(outliers["right_outliers"])}'
-            )
-        report_lines.append('')
-
-    # Excluded contigs
-    if excluded_contigs:
-        report_lines.append('## Excluded Contigs')
-        for contig in excluded_contigs:
-            report_lines.append(f'  {contig}')
-        report_lines.append('')
-
+    # ------------------------------------------------------------------
     # Warnings
+    # ------------------------------------------------------------------
     if warnings:
-        report_lines.append('## Warnings')
+        lines.append('## Warnings')
+        lines.append('')
         for warning in warnings:
-            report_lines.append(f'  - {warning}')
-        report_lines.append('')
+            lines.append(f'- {warning}')
+        lines.append('')
 
-    # Per-contig summary
-    report_lines.append('## Per-Contig Overhang Summary')
-    report_lines.append('Contig\tLength\tLeft_Count\tRight_Count')
-
-    for contig_name, contig_stats in stats_dict.items():
-        report_lines.append(
-            f'{contig_name}\t{contig_stats.contig_length}\t'
-            f'{contig_stats.left_count}\t{contig_stats.right_count}'
+    if extensions_applied and not dry_run:
+        lines.append(
+            'Note: extended contigs should be polished (e.g. Medaka for ONT data, '
+            'Pypolca for Illumina data) before downstream analysis.'
         )
+        lines.append('')
 
-    return '\n'.join(report_lines)
+    return '\n'.join(lines).rstrip() + '\n'
 
 
 def count_terminal_motifs(
@@ -863,6 +1088,7 @@ def extend(
             excluded_contigs = []
             warnings = []
             motif_stats = {}
+            post_motif_counts = {}
             all_stats = {}
 
             # Collect statistics for contigs that meet extension criteria
@@ -908,6 +1134,7 @@ def extend(
                     max_homopolymer=max_homopolymer,
                     motif_patterns=motif_patterns,
                     dry_run=dry_run,
+                    terminal_length=screen_terminal_bases,
                 )
 
                 if extension_result:
@@ -917,6 +1144,10 @@ def extend(
                     warnings.extend(extension_result.warnings)
                     if extension_result.motif_counts:
                         motif_stats[contig_name] = extension_result.motif_counts
+                    if extension_result.end_motif_counts:
+                        post_motif_counts[contig_name] = (
+                            extension_result.end_motif_counts
+                        )
 
                     # Log successful extension(s)
                     ext_info = extension_result.extension_info
@@ -998,6 +1229,9 @@ def extend(
             motif_stats,
             terminal_motif_counts,
             dry_run,
+            post_motif_counts=post_motif_counts,
+            screen_terminal_bases=screen_terminal_bases,
+            total_contigs=len(contig_dict),
         )
 
         # Write outputs

--- a/src/teloclip/commands/extract.py
+++ b/src/teloclip/commands/extract.py
@@ -1,10 +1,8 @@
-"""
-Extract sub-command for teloclip CLI.
-"""
+"""Extract sub-command for teloclip CLI."""
 
 import logging
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Dict
 
 import click
@@ -131,7 +129,7 @@ def extract_cmd(
     no_mask_overhangs,
     log_level,
 ):
-    """
+    r"""
     Extract overhanging reads for each end of each reference contig.
 
     Read SAM alignments and extracts soft-clipped sequences that
@@ -180,7 +178,6 @@ def extract_cmd(
 
     Examples
     --------
-
     # Basic extraction to current directory
     teloclip extract --ref-idx ref.fa.fai input.sam
 
@@ -197,7 +194,6 @@ def extract_cmd(
     samtools view -h input.bam | teloclip extract --ref-idx ref.fa.fai \\
         --count-motifs TTAGGG --fuzzy-count
     """
-
     # Initialize logging for this command
     init_logging(log_level)
 

--- a/src/teloclip/commands/extract.py
+++ b/src/teloclip/commands/extract.py
@@ -1,8 +1,8 @@
 """Extract sub-command for teloclip CLI."""
 
 import logging
-import sys
 from pathlib import Path
+import sys
 from typing import Dict
 
 import click

--- a/src/teloclip/extract_io.py
+++ b/src/teloclip/extract_io.py
@@ -5,10 +5,10 @@ This module provides memory-efficient FASTA/FASTQ writing with buffering,
 statistics tracking, and BioPython integration for the extract command.
 """
 
-from collections import defaultdict
 import logging
-from pathlib import Path
 import sys
+from collections import defaultdict
+from pathlib import Path
 from typing import Dict, Optional, Union
 
 from Bio import SeqIO
@@ -36,7 +36,8 @@ class EfficientSequenceWriter:
         output_format: str = 'fasta',
         buffer_size: int = 1000,
     ):
-        """Initialize writer with optional buffering.
+        """
+        Initialize writer with optional buffering.
 
         Parameters
         ----------
@@ -86,9 +87,7 @@ class EfficientSequenceWriter:
         self.close()
 
     def open(self):
-        """
-        Open output file handle.
-        """
+        """Open output file handle."""
         if self.output_path is None:
             self.file_handle = sys.stdout
         else:
@@ -172,9 +171,7 @@ class EfficientSequenceWriter:
             self.buffer.clear()
 
     def close(self):
-        """
-        Close writer and cleanup.
-        """
+        """Close writer and cleanup."""
         # Write any remaining buffered sequences
         if self.buffer:
             self.flush()
@@ -715,13 +712,13 @@ class StreamingGenomeProcessor:
     """
 
     def __init__(self, fasta_path: Union[str, Path]):
-        """
-        Initialize the streaming processor.
+        """Initialize the streaming processor.
 
         Parameters
         ----------
         fasta_path : str or Path
             Path to indexed FASTA file (.fai index required).
+
         """
         try:
             import pysam

--- a/src/teloclip/extract_io.py
+++ b/src/teloclip/extract_io.py
@@ -5,10 +5,10 @@ This module provides memory-efficient FASTA/FASTQ writing with buffering,
 statistics tracking, and BioPython integration for the extract command.
 """
 
-import logging
-import sys
 from collections import defaultdict
+import logging
 from pathlib import Path
+import sys
 from typing import Dict, Optional, Union
 
 from Bio import SeqIO

--- a/src/teloclip/motifs.py
+++ b/src/teloclip/motifs.py
@@ -31,8 +31,7 @@ def make_motif_regex(motif: str) -> str:
 
 def make_fuzzy_motif_regex(motif: str) -> str:
     """
-    Create a regex pattern to match fuzzy motifs with runs of characters
-    that differ by plus or minus one compared to the original motif.
+    Create a regex pattern to match fuzzy motifs with runs of characters that differ by plus or minus one compared to the original motif.
 
     Parameters
     ----------
@@ -108,7 +107,6 @@ def count_continuous_runs(dna_string: str) -> list:
         A list of tuples where each tuple contains a character and the number
         of times it occurred consecutively in the input DNA string.
     """
-
     # Check if the input string is empty
     if not dna_string:
         return []
@@ -137,8 +135,7 @@ def count_continuous_runs(dna_string: str) -> list:
 
 def construct_regex_pattern(motif_tuples: List[Tuple[str, int]]) -> str:
     """
-    Construct a regex pattern to match sequences with runs of characters
-    that differ by plus or minus one compared to the original input sequence.
+    Construct a regex pattern to match sequences with runs of characters that differ by plus or minus one compared to the original input sequence.
 
     Parameters
     ----------
@@ -151,7 +148,6 @@ def construct_regex_pattern(motif_tuples: List[Tuple[str, int]]) -> str:
     str
         The constructed regex pattern as a raw string.
     """
-
     pattern_parts = []
 
     # Note: This idea was adapted from https://github.com/JanaSperschneider/FindTelomeres/blob/master/FindTelomeres.py

--- a/src/teloclip/reporting.py
+++ b/src/teloclip/reporting.py
@@ -1,0 +1,197 @@
+"""
+Plain-text and Markdown formatting helpers for teloclip reports.
+
+This module provides small, dependency-free helpers used to build the
+statistics reports emitted by the teloclip sub-commands. Tables are written as
+GitHub-flavoured Markdown, padded so that they also read as aligned plain text
+in a terminal.
+"""
+
+from typing import List, Optional, Sequence, Tuple
+
+# Separator cell contents for each supported alignment code.
+_ALIGN_MARKERS = {
+    'l': '---',
+    'r': '---:',
+    'c': ':---:',
+}
+
+
+def fmt_int(value: int) -> str:
+    """
+    Format an integer with thousands separators.
+
+    Parameters
+    ----------
+    value : int
+        Value to format.
+
+    Returns
+    -------
+    str
+        The value rendered with comma thousands separators, e.g. ``'45,120'``.
+    """
+    return f'{value:,}'
+
+
+def fmt_delta(value: int) -> str:
+    """
+    Format a signed change in length.
+
+    Parameters
+    ----------
+    value : int
+        Change in length, in base pairs.
+
+    Returns
+    -------
+    str
+        A signed, comma-separated string such as ``'+180'`` or ``'-12'``.
+        Zero is rendered as ``'-'`` so that unchanged ends are visually quiet.
+    """
+    if value == 0:
+        return '-'
+    return f'{value:+,}'
+
+
+def fmt_float(value: float, dp: int = 1) -> str:
+    """
+    Format a float to a fixed number of decimal places.
+
+    Parameters
+    ----------
+    value : float
+        Value to format.
+    dp : int, optional
+        Number of decimal places to show (default: 1).
+
+    Returns
+    -------
+    str
+        The value rendered with ``dp`` decimal places.
+    """
+    return f'{value:,.{dp}f}'
+
+
+def md_table(
+    headers: Sequence[str],
+    rows: Sequence[Sequence[str]],
+    align: Optional[Sequence[str]] = None,
+) -> str:
+    """
+    Render a GitHub-flavoured Markdown table.
+
+    Cells are padded to a common width per column so that the raw text is also
+    aligned when viewed in a terminal.
+
+    Parameters
+    ----------
+    headers : Sequence[str]
+        Column header labels.
+    rows : Sequence[Sequence[str]]
+        Table body. Each row must have the same number of cells as ``headers``.
+    align : Optional[Sequence[str]], optional
+        Per-column alignment codes, one of ``'l'``, ``'r'`` or ``'c'``. Defaults
+        to left alignment for every column.
+
+    Returns
+    -------
+    str
+        The rendered table, or an empty string when ``rows`` is empty so that
+        callers can omit the surrounding section.
+
+    Raises
+    ------
+    ValueError
+        If a row or the ``align`` sequence does not match the header width, or
+        if an unknown alignment code is given.
+    """
+    if not rows:
+        return ''
+
+    ncols = len(headers)
+
+    if align is None:
+        align = ['l'] * ncols
+    elif len(align) != ncols:
+        raise ValueError(
+            f'align has {len(align)} entries but there are {ncols} columns'
+        )
+
+    for code in align:
+        if code not in _ALIGN_MARKERS:
+            raise ValueError(f'Unknown alignment code: {code!r}')
+
+    cells: List[List[str]] = [[str(h) for h in headers]]
+    for row in rows:
+        if len(row) != ncols:
+            raise ValueError(
+                f'Row has {len(row)} cells but there are {ncols} columns: {row!r}'
+            )
+        cells.append([str(c) for c in row])
+
+    widths = [max(len(row[i]) for row in cells) for i in range(ncols)]
+    # A right-aligned separator needs at least 4 characters ('---:').
+    widths = [max(w, len(_ALIGN_MARKERS[align[i]])) for i, w in enumerate(widths)]
+
+    def _render(row: Sequence[str]) -> str:
+        """
+        Render one row with each cell padded to its column width.
+
+        Parameters
+        ----------
+        row : Sequence[str]
+            Cell values for a single row.
+
+        Returns
+        -------
+        str
+            The pipe-delimited, padded row.
+        """
+        padded = []
+        for i, cell in enumerate(row):
+            if align[i] == 'r':
+                padded.append(cell.rjust(widths[i]))
+            elif align[i] == 'c':
+                padded.append(cell.center(widths[i]))
+            else:
+                padded.append(cell.ljust(widths[i]))
+        return '| ' + ' | '.join(padded) + ' |'
+
+    lines = [_render(cells[0])]
+    lines.append(
+        '| '
+        + ' | '.join(
+            _ALIGN_MARKERS[align[i]].rjust(widths[i])
+            if align[i] == 'r'
+            else _ALIGN_MARKERS[align[i]].ljust(widths[i])
+            for i in range(ncols)
+        )
+        + ' |'
+    )
+    lines.extend(_render(row) for row in cells[1:])
+
+    return '\n'.join(lines)
+
+
+def kv_table(pairs: Sequence[Tuple[str, str]], key_header: str = 'Metric') -> str:
+    """
+    Render a two-column metric/value table.
+
+    Parameters
+    ----------
+    pairs : Sequence[Tuple[str, str]]
+        Ordered ``(label, value)`` pairs.
+    key_header : str, optional
+        Header for the label column (default: ``'Metric'``).
+
+    Returns
+    -------
+    str
+        The rendered table, or an empty string when ``pairs`` is empty.
+    """
+    return md_table(
+        [key_header, 'Value'],
+        [[label, value] for label, value in pairs],
+        align=['l', 'r'],
+    )

--- a/src/teloclip/samops.py
+++ b/src/teloclip/samops.py
@@ -1,6 +1,4 @@
-"""
-SAM file operations for Teloclip.
-"""
+"""SAM file operations for Teloclip."""
 
 import logging
 import re
@@ -433,9 +431,7 @@ def validate_min_anchor(cigar_string, min_anchor):
 
 
 def SAMinfo():
-    """
-    Print samfile spec.
-    """
+    """Print samfile spec."""
     print(
         """
     # SAM format
@@ -456,9 +452,7 @@ def SAMinfo():
 
 
 def CIGARinfo():
-    """
-    Print CIGAR file spec.
-    """
+    """Print CIGAR file spec."""
     print(
         """
     CIGAR Operators
@@ -534,8 +528,7 @@ class EnhancedStreamingSamFilter:
         stats: Optional['ExtractionStats'] = None,
         exclude_secondary: bool = True,
     ):
-        """
-        Initialize enhanced streaming filter.
+        """Initialize enhanced streaming filter.
 
         Parameters
         ----------
@@ -557,6 +550,7 @@ class EnhancedStreamingSamFilter:
             Statistics tracker
         exclude_secondary : bool, optional
             If True, exclude secondary alignments. Default is True.
+
         """
         self.samfile = samfile
         self.contigs = contigs

--- a/src/teloclip/streaming_analysis.py
+++ b/src/teloclip/streaming_analysis.py
@@ -219,6 +219,7 @@ class ExtensionResult:
     extension_info: dict
     warnings: List[str] = field(default_factory=list)
     motif_counts: Dict[str, int] = field(default_factory=dict)
+    end_motif_counts: Dict[str, Dict[str, int]] = field(default_factory=dict)
 
 
 def process_single_contig_extension(
@@ -229,6 +230,7 @@ def process_single_contig_extension(
     max_homopolymer: int = 50,
     motif_patterns: Optional[Dict[str, str]] = None,
     dry_run: bool = False,
+    terminal_length: int = 0,
 ) -> Optional[ExtensionResult]:
     """
     Process extension for a single contig, handling both ends if valid.
@@ -249,6 +251,10 @@ def process_single_contig_extension(
         Motif patterns to search for.
     dry_run : bool, optional
         Whether this is a dry run (default: False).
+    terminal_length : int, optional
+        Number of original terminal bases to include in the per-end motif
+        counting window, alongside the length of the extension at that end
+        (default: 0).
 
     Returns
     -------
@@ -401,6 +407,7 @@ def process_single_contig_extension(
 
     # Count motifs if patterns provided
     motif_counts = {}
+    end_motif_counts: Dict[str, Dict[str, int]] = {}
     if motif_patterns:
         target_seq = working_sequence if not dry_run else original_sequence
 
@@ -415,6 +422,26 @@ def process_single_contig_extension(
             matches = re.findall(pattern_str, target_seq)
             motif_counts[pattern_name] = len(matches)
 
+        # Count motifs in an explicit window at each end of the extended
+        # sequence: the original terminal screening window plus whatever was
+        # added at that end. This makes the counts directly comparable with the
+        # pre-extension terminal counts.
+        left_added = final_extension_info.get('left_overhang_length', 0)
+        right_added = final_extension_info.get('right_overhang_length', 0)
+        left_window = min(terminal_length + left_added, len(target_seq))
+        right_window = min(terminal_length + right_added, len(target_seq))
+
+        end_motif_counts = {'left': {}, 'right': {}}
+        for pattern_name, pattern_str in motif_patterns.items():
+            left_seq = target_seq[:left_window] if left_window > 0 else ''
+            right_seq = target_seq[-right_window:] if right_window > 0 else ''
+            end_motif_counts['left'][pattern_name] = len(
+                re.findall(pattern_str, left_seq)
+            )
+            end_motif_counts['right'][pattern_name] = len(
+                re.findall(pattern_str, right_seq)
+            )
+
     return ExtensionResult(
         contig_name=contig_name,
         original_length=contig_stats.contig_length,
@@ -422,4 +449,5 @@ def process_single_contig_extension(
         extension_info=final_extension_info,
         warnings=warnings,
         motif_counts=motif_counts,
+        end_motif_counts=end_motif_counts,
     )

--- a/src/teloclip/streaming_io.py
+++ b/src/teloclip/streaming_io.py
@@ -5,13 +5,13 @@ This module provides streaming functions for processing large genomes without
 loading entire files into memory, using pysam for indexed access.
 """
 
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Dict, Iterator, Optional, Tuple, Union
 
+import pysam
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-import pysam
 
 
 class StreamingGenomeProcessor:

--- a/src/teloclip/streaming_io.py
+++ b/src/teloclip/streaming_io.py
@@ -5,13 +5,13 @@ This module provides streaming functions for processing large genomes without
 loading entire files into memory, using pysam for indexed access.
 """
 
-import sys
 from pathlib import Path
+import sys
 from typing import Dict, Iterator, Optional, Tuple, Union
 
-import pysam
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+import pysam
 
 
 class StreamingGenomeProcessor:

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -31,7 +31,8 @@ class CLIRunner:
             input_data: Data to pass to stdin
             check: If True, raise CalledProcessError on non-zero exit
 
-        Returns:
+        Returns
+        -------
             Tuple of (exit_code, stdout, stderr)
         """
         try:
@@ -68,7 +69,8 @@ class CLIRunner:
             input_data: Data to pass to stdin
             check: If True, raise CalledProcessError on non-zero exit
 
-        Returns:
+        Returns
+        -------
             Tuple of (exit_code, stdout, stderr)
         """
         cmd = ['teloclip'] + args
@@ -136,7 +138,8 @@ def create_test_files(temp_dir, minimal_sam_content, minimal_fasta_content):
             corrupt_sam: Create corrupted SAM file
             empty_files: Create empty files
 
-        Returns:
+        Returns
+        -------
             Dict with file paths
         """
         files = {}

--- a/tests/cli/test_extend_cli.py
+++ b/tests/cli/test_extend_cli.py
@@ -51,7 +51,8 @@ def test_files(test_data_dir, temp_dir):
             corrupt_files: Create corrupted versions of files
             empty_files: Create empty versions of files
 
-        Returns:
+        Returns
+        -------
             Dict with file paths
         """
         if copy_to_temp or corrupt_files or empty_files:
@@ -179,6 +180,12 @@ class TestExtendCLIBasicFunctionality:
 
         assert_exit_code(exit_code, 0, stdout, stderr)
         assert_file_exists(stats_file)
+
+        report = stats_file.read_text()
+        assert report.startswith('# Teloclip Extend Report')
+        assert '## Summary' in report
+        # Summary is rendered as a Markdown table.
+        assert '| Contigs in assembly' in report
 
 
 class TestExtendCLIParameterValidation:

--- a/tests/cli/test_extract_cli.py
+++ b/tests/cli/test_extract_cli.py
@@ -50,7 +50,8 @@ def test_files(test_data_dir, temp_dir):
             corrupt_files: Create corrupted versions of files
             empty_files: Create empty versions of files
 
-        Returns:
+        Returns
+        -------
             Dict with file paths
         """
         if copy_to_temp or corrupt_files or empty_files:

--- a/tests/cli/test_filter_cli.py
+++ b/tests/cli/test_filter_cli.py
@@ -50,7 +50,8 @@ def test_files(test_data_dir, temp_dir):
             corrupt_files: Create corrupted versions of files
             empty_files: Create empty versions of files
 
-        Returns:
+        Returns
+        -------
             Dict with file paths
         """
         if copy_to_temp or corrupt_files or empty_files:

--- a/tests/cli/test_main_cli.py
+++ b/tests/cli/test_main_cli.py
@@ -31,7 +31,8 @@ class CLIRunner:
             input_data: Data to pass to stdin
             check: If True, raise CalledProcessError on non-zero exit
 
-        Returns:
+        Returns
+        -------
             Tuple of (exit_code, stdout, stderr)
         """
         try:
@@ -68,7 +69,8 @@ class CLIRunner:
             input_data: Data to pass to stdin
             check: If True, raise CalledProcessError on non-zero exit
 
-        Returns:
+        Returns
+        -------
             Tuple of (exit_code, stdout, stderr)
         """
         cmd = ['teloclip'] + args

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
-"""
-Pytest configuration and fixtures for teloclip tests.
-"""
+"""Pytest configuration and fixtures for teloclip tests."""
 
 from pathlib import Path
 import tempfile

--- a/tests/integration/test_generate_alignments.py
+++ b/tests/integration/test_generate_alignments.py
@@ -478,7 +478,7 @@ def write_sam_file(
 
 
 def main():
-    """Main function to generate synthetic SAM alignments."""
+    """Generate synthetic SAM alignments."""
     parser = argparse.ArgumentParser(
         description='Generate synthetic SAM alignments for teloclip integration testing'
     )

--- a/tests/integration/test_generate_data.py
+++ b/tests/integration/test_generate_data.py
@@ -230,7 +230,7 @@ def write_fasta_file(contigs: Dict[str, str], output_path: Path) -> None:
 
 
 def main():
-    """Main function to generate test contigs."""
+    """Generate test contigs."""
     parser = argparse.ArgumentParser(
         description='Generate synthetic contigs for teloclip testing'
     )

--- a/tests/integration/test_validate_integration.py
+++ b/tests/integration/test_validate_integration.py
@@ -200,7 +200,7 @@ def run_integration_tests(quick: bool = False, verbose: bool = False) -> bool:
 
 
 def main():
-    """Main validation function."""
+    """Run the integration validation suite."""
     parser = argparse.ArgumentParser(
         description='Validate teloclip integration test framework'
     )

--- a/tests/test_anchor_validation.py
+++ b/tests/test_anchor_validation.py
@@ -1,6 +1,4 @@
-"""
-Tests for anchor validation functions in samops module.
-"""
+"""Tests for anchor validation functions in samops module."""
 
 from teloclip.samops import (
     calculate_aligned_bases,

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -1,3 +1,5 @@
+"""Tests for the teloclip.motifs module."""
+
 import pytest
 
 from teloclip.motifs import (
@@ -10,6 +12,7 @@ from teloclip.motifs import (
 
 
 def test_check_sequence_for_patterns():
+    """Check sequences against a list of regex patterns."""
     # Test case with a simple DNA sequence and patterns
     dna_sequence = 'ATCGATCGATCG'
     regex_patterns = ['ATC', 'GAT', 'CGA']
@@ -33,6 +36,7 @@ def test_check_sequence_for_patterns():
 
 
 def test_count_regex_patterns_in_sequence():
+    """Count regex pattern occurrences in a sequence."""
     # Test case with a simple DNA sequence and patterns
     dna_sequence = 'ATCGATCGATCG'
     regex_patterns = ['ATC', 'GAT', 'CGA']
@@ -59,6 +63,7 @@ def test_count_regex_patterns_in_sequence():
 
 
 def test_format_pattern_counts():
+    """Format a pattern-count mapping for display."""
     # Test case with a simple pattern counts dictionary
     pattern_counts = {'ATC': 3, 'GAT': 1, 'CGA': 2}
     assert format_pattern_counts(pattern_counts) == 'ATC=3:GAT=1:CGA=2'
@@ -75,6 +80,7 @@ def test_format_pattern_counts():
 
 
 def test_count_continuous_runs():
+    """Count continuous runs of identical bases."""
     # Test case with a simple sequence
     assert count_continuous_runs('AAATTTGGCCCG') == [
         ('A', 3),
@@ -102,6 +108,7 @@ def test_count_continuous_runs():
 
 
 def test_construct_regex_pattern():
+    """Construct a regex pattern from a motif sequence."""
     # Test case with a simple motif
     motif_sequence = 'TTTAGGG'
     motif_tuples = count_continuous_runs(motif_sequence)

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -434,6 +434,50 @@ class TestDualEndOverhang:
             'Should end with right overhang'
         )
 
+    def test_end_motif_counts_are_windowed_per_end(self):
+        """Per-end motif counts cover only the terminal window plus that extension."""
+        contig_stats = self.create_dual_end_contig_stats('spanning_read_001')
+        # Plant a motif deep in the contig interior; it must not be counted.
+        original_sequence = 'A' * 240 + 'TTAGGG' + 'A' * 254
+
+        result = self.process_extension(
+            contig_name='short_contig',
+            contig_stats=contig_stats,
+            original_sequence=original_sequence,
+            min_extension=1,
+            max_homopolymer=100,
+            motif_patterns={'TTAGGG': 'TTAGGG', 'CCCTAA': 'CCCTAA'},
+            dry_run=False,
+            terminal_length=10,
+        )
+
+        assert result is not None
+
+        # Whole-sequence counts still see the interior match.
+        assert result.motif_counts['TTAGGG'] == 4  # 3 in the left overhang + 1 interior
+
+        # Per-end windows are 10 + 18 = 28bp and exclude the interior match.
+        assert result.end_motif_counts['left'] == {'TTAGGG': 3, 'CCCTAA': 0}
+        assert result.end_motif_counts['right'] == {'TTAGGG': 0, 'CCCTAA': 3}
+
+    def test_end_motif_counts_empty_without_patterns(self):
+        """No per-end counts are produced when no motifs were requested."""
+        contig_stats = self.create_dual_end_contig_stats('spanning_read_001')
+
+        result = self.process_extension(
+            contig_name='short_contig',
+            contig_stats=contig_stats,
+            original_sequence='A' * 500,
+            min_extension=1,
+            max_homopolymer=100,
+            motif_patterns=None,
+            dry_run=False,
+            terminal_length=10,
+        )
+
+        assert result is not None
+        assert result.end_motif_counts == {}
+
     def test_dual_end_with_competing_overhangs(self):
         """Test when the dual-end read competes with other shorter overhangs."""
         contig_stats = self.create_dual_end_contig_stats('long_spanning_read')

--- a/tests/unit/test_extend_report.py
+++ b/tests/unit/test_extend_report.py
@@ -1,0 +1,374 @@
+"""Unit tests for the `teloclip extend` statistics report."""
+
+import pytest
+
+from teloclip.analysis import ContigStats, OverhangInfo
+from teloclip.commands.extend import generate_extension_report
+
+
+def make_overhang(length, is_left, contig='contig01', read='read1'):
+    """
+    Build a minimal OverhangInfo for report tests.
+
+    Parameters
+    ----------
+    length : int
+        Overhang length in bases.
+    is_left : bool
+        Whether the overhang is at the left end of the contig.
+    contig : str, optional
+        Contig name.
+    read : str, optional
+        Read name.
+
+    Returns
+    -------
+    OverhangInfo
+        A populated overhang record.
+    """
+    return OverhangInfo(
+        sequence='A' * length,
+        length=length,
+        alignment_pos=0,
+        alignment_end=length,
+        read_name=read,
+        is_left=is_left,
+        clip_length=length,
+        anchor_length=100,
+        contig_name=contig,
+    )
+
+
+def cells(line):
+    """
+    Split a rendered Markdown table row into stripped cell values.
+
+    Parameters
+    ----------
+    line : str
+        A single rendered table line.
+
+    Returns
+    -------
+    list of str
+        The cell contents, with padding removed.
+    """
+    return [cell.strip() for cell in line.strip().strip('|').split('|')]
+
+
+def find_row(report, first_cell):
+    """
+    Find the first table row whose leading cell matches.
+
+    Parameters
+    ----------
+    report : str
+        The rendered report.
+    first_cell : str
+        Expected value of the row's first cell.
+
+    Returns
+    -------
+    list of str
+        The matching row's stripped cells.
+
+    Raises
+    ------
+    AssertionError
+        If no row matches.
+    """
+    for line in report.split('\n'):
+        if line.startswith('|'):
+            row = cells(line)
+            if row and row[0] == first_cell:
+                return row
+    raise AssertionError(f'no row starting with {first_cell!r}')
+
+
+@pytest.fixture
+def stats_dict():
+    """
+    Provide overhang statistics for a single contig with both ends supported.
+
+    Returns
+    -------
+    dict
+        Mapping of contig name to ContigStats.
+    """
+    return {
+        'contig01': ContigStats(
+            contig_name='contig01',
+            contig_length=1000,
+            left_overhangs=[
+                make_overhang(50, True, read='readL1'),
+                make_overhang(60, True, read='readL2'),
+            ],
+            right_overhangs=[make_overhang(80, False, read='readR1')],
+        )
+    }
+
+
+@pytest.fixture
+def both_ends_extension():
+    """
+    Provide an extension record for a contig extended at both ends.
+
+    Returns
+    -------
+    dict
+        Mapping of contig name to extension info.
+    """
+    return {
+        'contig01': {
+            'original_length': 1000,
+            'final_length': 1135,
+            'has_left_extension': True,
+            'left_overhang_length': 60,
+            'left_read_name': 'readL2',
+            'left_trim_length': 5,
+            'has_right_extension': True,
+            'right_overhang_length': 80,
+            'right_read_name': 'readR1',
+            'right_trim_length': 0,
+        }
+    }
+
+
+@pytest.fixture
+def empty_outliers():
+    """
+    Provide an empty outlier mapping.
+
+    Returns
+    -------
+    dict
+        Mapping with empty left and right outlier lists.
+    """
+    return {'left_outliers': [], 'right_outliers': []}
+
+
+def test_report_has_expected_sections(stats_dict, both_ends_extension, empty_outliers):
+    """The report opens with a title and summary, then the detail tables."""
+    report = generate_extension_report(
+        stats_dict,
+        both_ends_extension,
+        empty_outliers,
+        {},
+        [],
+        [],
+    )
+    assert report.startswith('# Teloclip Extend Report')
+    assert '## Summary' in report
+    assert '## Extensions Applied' in report
+    assert '## Per-Contig Overhang Support' in report
+
+
+def test_summary_counts_both_ends(stats_dict, both_ends_extension, empty_outliers):
+    """A contig extended at both ends contributes two ends and the summed bases."""
+    report = generate_extension_report(
+        stats_dict,
+        both_ends_extension,
+        empty_outliers,
+        {},
+        [],
+        [],
+        total_contigs=1,
+    )
+    assert 'Contig ends extended' in report
+    assert '2 of 2' in report
+    assert '| Total bases added' in report
+    assert '140' in report  # 60 + 80
+    assert '| Total bases trimmed back' in report
+
+
+def test_extensions_table_reports_both_ends(
+    stats_dict, both_ends_extension, empty_outliers
+):
+    """Both left and right extension lengths appear, not just one."""
+    report = generate_extension_report(
+        stats_dict,
+        both_ends_extension,
+        empty_outliers,
+        {},
+        [],
+        [],
+    )
+    row = find_row(report, 'contig01')
+    assert row[1] == '1,000'
+    assert row[2] == '1,135'
+    assert row[3] == '+60'
+    assert row[4] == '+80'
+    assert row[5] == '+140'
+    assert row[6] == 'readL2'
+    assert row[7] == 'readR1'
+    assert row[8] == '5'
+
+
+def test_motif_gain_is_attributed_per_end(
+    stats_dict, both_ends_extension, empty_outliers
+):
+    """
+    Motif gain is computed per contig end.
+
+    Regression test: the previous report guessed a single end from the legacy
+    `is_left` flag, charging a both-ends contig's entire gain to the left end.
+    """
+    terminal = {'contig01': {'left': {'TTAGGG': 1}, 'right': {'TTAGGG': 2}}}
+    post = {'contig01': {'left': {'TTAGGG': 6}, 'right': {'TTAGGG': 12}}}
+
+    report = generate_extension_report(
+        stats_dict,
+        both_ends_extension,
+        empty_outliers,
+        {},
+        [],
+        [],
+        terminal_motif_counts=terminal,
+        post_motif_counts=post,
+        screen_terminal_bases=1000,
+    )
+
+    assert '## Telomere Motif Analysis' in report
+    motif_rows = [
+        cells(line)
+        for line in report.split('\n')
+        if line.startswith('| contig01 |') and ' TTAGGG ' in line
+    ]
+    left_row = next(r for r in motif_rows if r[1] == 'left')
+    right_row = next(r for r in motif_rows if r[1] == 'right')
+    # Windows are the screening window plus that end's extension.
+    assert left_row[3] == '1,060'
+    assert left_row[4:] == ['1', '6', '+5']
+    assert right_row[3] == '1,080'
+    assert right_row[4:] == ['2', '12', '+10']
+    assert 'Total motif gain: +15' in report
+
+
+def test_motif_section_omitted_without_counts(
+    stats_dict, both_ends_extension, empty_outliers
+):
+    """No motif section is emitted when --count-motifs was not used."""
+    report = generate_extension_report(
+        stats_dict,
+        both_ends_extension,
+        empty_outliers,
+        {},
+        [],
+        [],
+    )
+    assert '## Telomere Motif Analysis' not in report
+    assert 'Total motif gain' not in report
+
+
+def test_dry_run_title_and_wording(stats_dict, both_ends_extension, empty_outliers):
+    """Dry runs are labelled and do not carry the polishing note."""
+    report = generate_extension_report(
+        stats_dict,
+        both_ends_extension,
+        empty_outliers,
+        {},
+        [],
+        [],
+        dry_run=True,
+    )
+    assert report.startswith('# Teloclip Extend Report (dry run)')
+    assert '## Extensions That Would Be Applied' in report
+    assert 'should be polished' not in report
+
+
+def test_empty_sections_are_omitted(stats_dict, empty_outliers):
+    """Sections with no content are skipped rather than left as bare headings."""
+    report = generate_extension_report(
+        stats_dict,
+        {},
+        empty_outliers,
+        {},
+        [],
+        [],
+    )
+    assert '## Extensions Applied' not in report
+    assert '## Excluded Contigs' not in report
+    assert '## Warnings' not in report
+
+
+def test_excluded_and_warnings_rendered(stats_dict, empty_outliers):
+    """Excluded contigs get a reason, and warnings are bulleted."""
+    report = generate_extension_report(
+        stats_dict,
+        {},
+        {'left_outliers': ['contig09'], 'right_outliers': []},
+        {},
+        ['chrM'],
+        ['terminal screening window exceeds contig length'],
+    )
+    assert '## Excluded Contigs' in report
+    assert '| chrM' in report
+    assert 'user exclusion list' in report
+    assert 'contig09' in report
+    assert 'left overhang outlier' in report
+    assert '## Warnings' in report
+    assert '- terminal screening window exceeds contig length' in report
+
+
+def test_overhang_statistics_table(stats_dict, empty_outliers):
+    """Overhang counts come from the contig stats, min/max render as integers."""
+    overall = {
+        'left': {'mean': 55.0, 'median': 55.0, 'std_dev': 7.07, 'min': 50, 'max': 60},
+        'right': {'mean': 80.0, 'median': 80.0, 'std_dev': 0.0, 'min': 80, 'max': 80},
+        'combined': {
+            'mean': 63.3,
+            'median': 60.0,
+            'std_dev': 15.3,
+            'min': 50,
+            'max': 80,
+        },
+    }
+    report = generate_extension_report(
+        stats_dict,
+        {},
+        empty_outliers,
+        overall,
+        [],
+        [],
+    )
+    assert '## Overhang Length Statistics' in report
+    left_row = find_row(report, 'Left')
+    assert left_row[1] == '2'  # two left overhangs in the fixture
+    # Min/Max render as integers, not 50.00 / 60.00
+    assert left_row[5] == '50'
+    assert left_row[6] == '60'
+    assert find_row(report, 'Combined')[1] == '3'
+
+
+def test_per_contig_support_flags_extension_state(
+    stats_dict, both_ends_extension, empty_outliers
+):
+    """The support table records which ends were actually extended."""
+    report = generate_extension_report(
+        stats_dict,
+        both_ends_extension,
+        empty_outliers,
+        {},
+        [],
+        [],
+    )
+    row = find_row(report[report.index('## Per-Contig') :], 'contig01')
+    assert row[2] == '2'  # left read count
+    assert row[3] == '1'  # right read count
+    assert row[4] == '60'  # longest left overhang
+    assert row[5] == '80'  # longest right overhang
+    assert row[6] == 'both'
+
+
+def test_per_contig_support_marks_unextended(stats_dict, empty_outliers):
+    """Contigs with support but no extension are marked 'no'."""
+    report = generate_extension_report(
+        stats_dict,
+        {},
+        empty_outliers,
+        {},
+        [],
+        [],
+    )
+    row = find_row(report[report.index('## Per-Contig') :], 'contig01')
+    assert row[6] == 'no'

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -1,0 +1,92 @@
+"""Unit tests for the teloclip.reporting formatting helpers."""
+
+import pytest
+
+from teloclip.reporting import fmt_delta, fmt_float, fmt_int, kv_table, md_table
+
+
+def test_fmt_int_adds_thousands_separators():
+    """Integers are rendered with comma separators."""
+    assert fmt_int(0) == '0'
+    assert fmt_int(999) == '999'
+    assert fmt_int(45120) == '45,120'
+    assert fmt_int(6031340) == '6,031,340'
+
+
+def test_fmt_delta_signs_and_zero():
+    """Deltas are signed, and zero renders as a dash."""
+    assert fmt_delta(180) == '+180'
+    assert fmt_delta(-12) == '-12'
+    assert fmt_delta(0) == '-'
+    assert fmt_delta(1234) == '+1,234'
+
+
+def test_fmt_float_decimal_places():
+    """Floats honour the requested number of decimal places."""
+    assert fmt_float(58.888) == '58.9'
+    assert fmt_float(58.888, dp=2) == '58.89'
+    assert fmt_float(1234.5) == '1,234.5'
+
+
+def test_md_table_empty_rows_returns_empty_string():
+    """An empty body yields an empty string so callers can skip the section."""
+    assert md_table(['A', 'B'], []) == ''
+
+
+def test_md_table_separator_encodes_alignment():
+    """The separator row uses the GFM markers for each alignment code."""
+    table = md_table(
+        ['Left', 'Right', 'Centre'],
+        [['a', 'b', 'c']],
+        align=['l', 'r', 'c'],
+    )
+    separator = table.split('\n')[1]
+    cells = [cell.strip() for cell in separator.strip('|').split('|')]
+    assert cells == ['---', '---:', ':---:']
+
+
+def test_md_table_pads_columns_to_common_width():
+    """Every rendered line is the same width, so raw text stays aligned."""
+    table = md_table(
+        ['Contig', 'Length'],
+        [['contig01', '560'], ['a_much_longer_contig', '1,610']],
+        align=['l', 'r'],
+    )
+    lines = table.split('\n')
+    assert len({len(line) for line in lines}) == 1
+    # Right-aligned values are flushed to the right of their column.
+    assert lines[2].endswith('|    560 |')
+
+
+def test_md_table_row_width_mismatch_raises():
+    """A row with the wrong number of cells is an error, not silent truncation."""
+    with pytest.raises(ValueError, match='2 cells'):
+        md_table(['A', 'B', 'C'], [['x', 'y']])
+
+
+def test_md_table_bad_align_code_raises():
+    """Unknown alignment codes are rejected."""
+    with pytest.raises(ValueError, match='alignment code'):
+        md_table(['A'], [['x']], align=['x'])
+
+
+def test_md_table_align_length_mismatch_raises():
+    """The align sequence must match the number of columns."""
+    with pytest.raises(ValueError, match='2 entries'):
+        md_table(['A', 'B', 'C'], [['x', 'y', 'z']], align=['l', 'r'])
+
+
+def test_kv_table_shape():
+    """kv_table renders a two-column Metric/Value table."""
+    table = kv_table([('Contigs extended', '4'), ('Total bases added', '551')])
+    lines = table.split('\n')
+    assert lines[0].startswith('| Metric')
+    assert 'Value' in lines[0]
+    assert len(lines) == 4  # header, separator, two rows
+    assert 'Contigs extended' in lines[2]
+
+
+def test_kv_table_custom_key_header():
+    """The label column header can be overridden."""
+    table = kv_table([('a', 'b')], key_header='Setting')
+    assert table.split('\n')[0].startswith('| Setting')


### PR DESCRIPTION
Misc fixes for unclear logging and reports.

Minor UX updates after case testing.

- [ ] Validate and tune automated contig exclusion. (--outlier-threshold )
- [ ] Add report per contig end: total count overhangs, median overhang length, overhang SD
- [ ] Improve extension summary reports.
- [ ] Log per contig total left/right overhang counts.
- [ ] Log histogram for per contig end overhang count in filter and extend.
- [ ] Add html report option for extend module
- [ ] Clarify exclusion stats in filter module
- [ ] Possible OBO error in clip threshold calculation
- [ ] Verify that exclusion contigs actually exist in ref asm index.
- [ ] Option to set logfile name
- [ ] Option to log all overhang reads with: contig end, clip offset from end of contig, len clip, and len overhang. 
- [ ] When excluding contigs from extension, they end up being written to the end of the output fasta. Fix so that output contigs maintain input order. [should we bother? Could just sort with seqtk afterwards.]